### PR TITLE
Refresh timeline image for EL10

### DIFF
--- a/common/img/centos_rhel_timeline.png
+++ b/common/img/centos_rhel_timeline.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33d9a69eda7ccba8d751e618b71c5f17422f7678469288d07c8bf6d03f7ffd38
-size 19865

--- a/common/img/centos_rhel_timeline.svg
+++ b/common/img/centos_rhel_timeline.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.0//EN" "http://www.w3.org/TR/2001/PR-SVG-20010719/DTD/svg10.dtd">
+<svg width="40cm" height="10cm" viewBox="-1 -68 784 192" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #a14f8c" x1="200" y1="60" x2="280" y2="-20"/>
+  <text font-size="12.8" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="40" y="-960">
+    <tspan x="40" y="-960"></tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="340" y="0">
+    <tspan x="340" y="0">CentOS Stream 10</tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="440" y="-40">
+    <tspan x="440" y="-40">RHEL 10.0</tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="560" y="-40">
+    <tspan x="560" y="-40">RHEL 10.1</tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="200" y="80">
+    <tspan x="200" y="80">Fedora 40</tspan>
+  </text>
+  <text font-size="12.8" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="120.787" y="-1017.91">
+    <tspan x="120.787" y="-1017.91"></tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="320" y="80">
+    <tspan x="320" y="80">Fedora 41</tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="80" y="80">
+    <tspan x="80" y="80">Fedora 39</tspan>
+  </text>
+  <text font-size="12.8" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="90" y="-660">
+    <tspan x="90" y="-660"></tspan>
+  </text>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="0" y1="100" x2="770.264" y2="100"/>
+    <polygon style="fill: #51a2da" points="777.764,100 767.764,105 770.264,100 767.764,95 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="777.764,100 767.764,105 770.264,100 767.764,95 "/>
+  </g>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="160" y1="100" x2="200" y2="60"/>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="280" y1="100" x2="320" y2="60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="320" y1="60" x2="410.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="417.764,60 407.764,65 410.264,60 407.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="417.764,60 407.764,65 410.264,60 407.764,55 "/>
+  </g>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="40" y1="100" x2="80" y2="60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="80" y1="60" x2="170.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="177.764,60 167.764,65 170.264,60 167.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="177.764,60 167.764,65 170.264,60 167.764,55 "/>
+  </g>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="400" y1="100" x2="440" y2="60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="440" y1="60" x2="530.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="537.764,60 527.764,65 530.264,60 527.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="537.764,60 527.764,65 530.264,60 527.764,55 "/>
+  </g>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="440" y="80">
+    <tspan x="440" y="80">Fedora 42</tspan>
+  </text>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="520" y1="100" x2="560" y2="60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="560" y1="60" x2="650.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="657.764,60 647.764,65 650.264,60 647.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="657.764,60 647.764,65 650.264,60 647.764,55 "/>
+  </g>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="560" y="80">
+    <tspan x="560" y="80">Fedora 43</tspan>
+  </text>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #ee0000" x1="400" y1="-20" x2="440" y2="-60"/>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #ee0000" x1="520" y1="-20" x2="560" y2="-60"/>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #51a2da" x1="640" y1="100" x2="680" y2="60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="680" y1="60" x2="770.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="777.764,60 767.764,65 770.264,60 767.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="777.764,60 767.764,65 770.264,60 767.764,55 "/>
+  </g>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="680" y="80">
+    <tspan x="680" y="80">Fedora 44</tspan>
+  </text>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="80" y="120">
+    <tspan x="80" y="120">Fedora Rawhide</tspan>
+  </text>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #a14f8c" x1="340" y1="-20" x2="280" y2="-20"/>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #ee0000" x1="640" y1="-20" x2="680" y2="-60"/>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="680" y="-40">
+    <tspan x="680" y="-40">RHEL 10.2</tspan>
+  </text>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" x1="200" y1="60" x2="290.264" y2="60"/>
+    <polygon style="fill: #51a2da" points="297.764,60 287.764,65 290.264,60 287.764,55 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #51a2da" points="297.764,60 287.764,65 290.264,60 287.764,55 "/>
+  </g>
+  <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #ee0000" x1="280" y1="-20" x2="320" y2="-60"/>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke-dasharray: 4; stroke: #ee0000" x1="320" y1="-60" x2="410.264" y2="-60"/>
+    <polygon style="fill: #ee0000" points="417.764,-60 407.764,-55 410.264,-60 407.764,-65 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" points="417.764,-60 407.764,-55 410.264,-60 407.764,-65 "/>
+  </g>
+  <text font-size="14.6756" style="fill: #000000;text-anchor:start;font-family:sans-serif;font-style:normal;font-weight:normal" x="320" y="-40">
+    <tspan x="320" y="-40">RHEL 10 Beta</tspan>
+  </text>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" x1="440" y1="-60" x2="530.264" y2="-60"/>
+    <polygon style="fill: #ee0000" points="537.764,-60 527.764,-55 530.264,-60 527.764,-65 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" points="537.764,-60 527.764,-55 530.264,-60 527.764,-65 "/>
+  </g>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" x1="560" y1="-60" x2="650.264" y2="-60"/>
+    <polygon style="fill: #ee0000" points="657.764,-60 647.764,-55 650.264,-60 647.764,-65 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" points="657.764,-60 647.764,-55 650.264,-60 647.764,-65 "/>
+  </g>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" x1="680" y1="-60" x2="770.264" y2="-60"/>
+    <polygon style="fill: #ee0000" points="777.764,-60 767.764,-55 770.264,-60 767.764,-65 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #ee0000" points="777.764,-60 767.764,-55 770.264,-60 767.764,-65 "/>
+  </g>
+  <g>
+    <line style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #a14f8c" x1="340" y1="-20" x2="770.264" y2="-20"/>
+    <polygon style="fill: #a14f8c" points="777.764,-20 767.764,-15 770.264,-20 767.764,-25 "/>
+    <polygon style="fill: none; fill-opacity:0; stroke-width: 2; stroke: #a14f8c" points="777.764,-20 767.764,-15 770.264,-20 767.764,-25 "/>
+  </g>
+</svg>

--- a/en-US/index.html
+++ b/en-US/index.html
@@ -29,7 +29,7 @@
       <p>Before a package is formally introduced to CentOS Stream, it undergoes a battery of tests and checks—both automated and manual—to ensure it meets the stringent standards for inclusion in RHEL. Updates posted to Stream are identical to those posted to the unreleased minor version of RHEL. The aim? For CentOS Stream to be as fundamentally stable as RHEL itself.</p>
       <p>To achieve this stability, each major release of Stream starts from a stable release of Fedora Linux—In CentOS Stream 10, this begins with Fedora 40, which is the same code base from which RHEL 10 is built. As updated packages pass testing and meet standards for stability, they are pushed into CentOS Stream as well as the nightly build of RHEL. What CentOS Stream looks like now is what RHEL will look like in the near future.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
         <figcaption class="figure-caption">
           OS Versions as they move from Fedora to CentOS Stream to Red Hat Enterprise Linux.
         </figcaption>

--- a/es-ES/index.html
+++ b/es-ES/index.html
@@ -29,7 +29,7 @@
       <p>Los paquetes de software antes de entrar formalmente a CentOS Stream están sujetos a una batería de pruebas y verificaciones, tanto automáticas como manuales, para asegurar que cumplen los estrictos estándares de los paquetes que se incluyen en RHEL. Las actualizaciones que recibe CentOS Stream son idénticas a las actualizaciones que recibe la versión menor de RHEL que aún no ha sido liberada. ¿A qué apunta esto? A que CentOS Stream sea fundamentalmente tan estable como lo es el propio RHEL.</p>
       <p>Para lograr esta estabilidad, cada liberación mayor de CentOS Stream comienza con una liberación estable de Fedora—En el caso de CentOS Stream 10 esto comienza con Fedora 40, que es el mismo código base desde el cual se construye RHEL 10. A medida que los paquetes actualizados pasan las pruebas y cumplen los estándares de estabilidad estos se van introduciendo en CentOS Stream como la construcción nocturna de RHEL. Lo que ves en CentOS Stream ahora es lo que verás en RHEL en el futuro.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="Cómo Fedora se transforma en CentOS; Cómo CentOS se transforma en RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="Cómo Fedora se transforma en CentOS; Cómo CentOS se transforma en RHEL" />
         <figcaption class="figure-caption">
           Versiones de los sistemas operativos mientras pasan de Fedora a CentOS Stream a RHEL.
         </figcaption>

--- a/it-IT/index.html
+++ b/it-IT/index.html
@@ -29,7 +29,7 @@
       <p>Before a package is formally introduced to CentOS Stream, it undergoes a battery of tests and checks—both automated and manual—to ensure it meets the stringent standards for inclusion in RHEL. Updates posted to Stream are identical to those posted to the unreleased minor version of RHEL. The aim? For CentOS Stream to be as fundamentally stable as RHEL itself.</p>
       <p>To achieve this stability, each major release of Stream starts from a stable release of Fedora Linux—In CentOS Stream 10, this begins with Fedora 40, which is the same code base from which RHEL 10 is built. As updated packages pass testing and meet standards for stability, they are pushed into CentOS Stream as well as the nightly build of RHEL. What CentOS Stream looks like now is what RHEL will look like in the near future.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
         <figcaption class="figure-caption">
           OS Versions as they move from Fedora to CentOS Stream to Red Hat Enterprise Linux.
         </figcaption>

--- a/zh-CN/index.html
+++ b/zh-CN/index.html
@@ -29,7 +29,7 @@
       <p>Before a package is formally introduced to CentOS Stream, it undergoes a battery of tests and checks—both automated and manual—to ensure it meets the stringent standards for inclusion in RHEL. Updates posted to Stream are identical to those posted to the unreleased minor version of RHEL. The aim? For CentOS Stream to be as fundamentally stable as RHEL itself.</p>
       <p>To achieve this stability, each major release of Stream starts from a stable release of Fedora Linux—In CentOS Stream 10, this begins with Fedora 40, which is the same code base from which RHEL 10 is built. As updated packages pass testing and meet standards for stability, they are pushed into CentOS Stream as well as the nightly build of RHEL. What CentOS Stream looks like now is what RHEL will look like in the near future.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
         <figcaption class="figure-caption">
           OS Versions as they move from Fedora to CentOS Stream to Red Hat Enterprise Linux.
         </figcaption>

--- a/zh-HK/index.html
+++ b/zh-HK/index.html
@@ -29,7 +29,7 @@
       <p>Before a package is formally introduced to CentOS Stream, it undergoes a battery of tests and checks—both automated and manual—to ensure it meets the stringent standards for inclusion in RHEL. Updates posted to Stream are identical to those posted to the unreleased minor version of RHEL. The aim? For CentOS Stream to be as fundamentally stable as RHEL itself.</p>
       <p>To achieve this stability, each major release of Stream starts from a stable release of Fedora Linux—In CentOS Stream 10, this begins with Fedora 40, which is the same code base from which RHEL 10 is built. As updated packages pass testing and meet standards for stability, they are pushed into CentOS Stream as well as the nightly build of RHEL. What CentOS Stream looks like now is what RHEL will look like in the near future.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
         <figcaption class="figure-caption">
           OS Versions as they move from Fedora to CentOS Stream to Red Hat Enterprise Linux.
         </figcaption>

--- a/zh-TW/index.html
+++ b/zh-TW/index.html
@@ -29,7 +29,7 @@
       <p>Before a package is formally introduced to CentOS Stream, it undergoes a battery of tests and checks—both automated and manual—to ensure it meets the stringent standards for inclusion in RHEL. Updates posted to Stream are identical to those posted to the unreleased minor version of RHEL. The aim? For CentOS Stream to be as fundamentally stable as RHEL itself.</p>
       <p>To achieve this stability, each major release of Stream starts from a stable release of Fedora Linux—In CentOS Stream 10, this begins with Fedora 40, which is the same code base from which RHEL 10 is built. As updated packages pass testing and meet standards for stability, they are pushed into CentOS Stream as well as the nightly build of RHEL. What CentOS Stream looks like now is what RHEL will look like in the near future.</p>
       <figure class="figure">
-        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.png" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
+        <img class="figure-img img-fluid" src="../common/img/centos_rhel_timeline.svg" alt="How Fedora becomes CentOS; how CentOS becomes RHEL" />
         <figcaption class="figure-caption">
           OS Versions as they move from Fedora to CentOS Stream to Red Hat Enterprise Linux.
         </figcaption>


### PR DESCRIPTION
This updates the timeline image from F34/C9/RHEL9 to F40/C10/RHEL10.  It also switches from png to svg format for better scaling and a smaller file size.